### PR TITLE
修复：getURLParameters 函数

### DIFF
--- a/src/core/getURLParameters.js
+++ b/src/core/getURLParameters.js
@@ -9,9 +9,9 @@
  */
 function getURLParameters(url = window.location.href) {
   if (typeof url !== 'string') throw new TypeError('数据类型必须是 string');
-  return url
-    .match(/([^?=&]+)(=([^&]*))/g)
-    .reduce((a, v) => ((a[v.slice(0, v.indexOf('='))] = v.slice(v.indexOf('=') + 1)), a), {});
+  let paramsArr = url.match(/([^?=&]+)(=([^&]*))/g)
+  if (!paramsArr) return {}
+  return paramsArr.reduce((a, v) => ((a[v.slice(0, v.indexOf('='))] = v.slice(v.indexOf('=') + 1)), a), {})
 }
 
 export default getURLParameters;


### PR DESCRIPTION
当url没有参数的时候，match到结果为null，导致reduce报错